### PR TITLE
[WIP] Delete link for font-awesome's CDN

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,5 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    %link{:href => "https://use.fontawesome.com/releases/v5.6.1/css/all.css", :rel => "stylesheet"}/
   %body
     = yield

--- a/app/views/products/_main.html.haml
+++ b/app/views/products/_main.html.haml
@@ -34,7 +34,7 @@
                 .item-box__content__num__price ¥ 2,000
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m74682669656/"}
@@ -47,7 +47,7 @@
                 .item-box__content__num__price ¥ 38,800
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m39424187987/"}
@@ -60,7 +60,7 @@
                 .item-box__content__num__price ¥ 2,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m19150720885/"}
@@ -73,7 +73,7 @@
                 .item-box__content__num__price ¥ 38,100
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -92,7 +92,7 @@
                 .item-box__content__num__price ¥ 2,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m81958640537/"}
@@ -105,7 +105,7 @@
                 .item-box__content__num__price ¥ 3,980
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m92734406078/"}
@@ -118,7 +118,7 @@
                 .item-box__content__num__price ¥ 16,450
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m12176688984/"}
@@ -131,7 +131,7 @@
                 .item-box__content__num__price ¥ 1,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -150,7 +150,7 @@
                 .item-box__content__num__price ¥ 400
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m13479538655/"}
@@ -163,7 +163,7 @@
                 .item-box__content__num__price ¥ 366
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m34654537430/"}
@@ -176,7 +176,7 @@
                 .item-box__content__num__price ¥ 1,200
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m48368597409/"}
@@ -189,7 +189,7 @@
                 .item-box__content__num__price ¥ 1,300
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -208,7 +208,7 @@
                 .item-box__content__num__price ¥ 1,400
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m15030474244/"}
@@ -221,7 +221,7 @@
                 .item-box__content__num__price ¥ 2,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m93621412035/"}
@@ -234,7 +234,7 @@
                 .item-box__content__num__price ¥ 1,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m22027905306/"}
@@ -247,7 +247,7 @@
                 .item-box__content__num__price ¥ 3,799
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -269,7 +269,7 @@
                 .item-box__content__num__price ¥ 2,600
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m86373005509/"}
@@ -282,7 +282,7 @@
                 .item-box__content__num__price ¥ 33,000
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m70071341205/"}
@@ -295,7 +295,7 @@
                 .item-box__content__num__price ¥ 15,000
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m75406084906/"}
@@ -308,7 +308,7 @@
                 .item-box__content__num__price ¥ 3,999
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -327,7 +327,7 @@
                 .item-box__content__num__price ¥ 5,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m37580062047/"}
@@ -340,7 +340,7 @@
                 .item-box__content__num__price ¥ 18,700
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m23199611463/"}
@@ -353,7 +353,7 @@
                 .item-box__content__num__price ¥ 8,000
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m90662868329/"}
@@ -366,7 +366,7 @@
                 .item-box__content__num__price ¥ 29,980
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -385,7 +385,7 @@
                 .item-box__content__num__price ¥ 10,000
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m52579936800/"}
@@ -398,7 +398,7 @@
                 .item-box__content__num__price ¥ 43,999
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m79624941794/"}
@@ -411,7 +411,7 @@
                 .item-box__content__num__price ¥ 7,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m94649124273/"}
@@ -424,7 +424,7 @@
                 .item-box__content__num__price ¥ 80,299
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る
@@ -443,7 +443,7 @@
                 .item-box__content__num__price ¥ 4,100
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m32936375902/"}
@@ -456,7 +456,7 @@
                 .item-box__content__num__price ¥ 24,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m41810334549/"}
@@ -469,7 +469,7 @@
                 .item-box__content__num__price ¥ 4,999
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
         %li.item-box
           %a{:href => "https://item.mercari.com/jp/m32657487396/"}
@@ -482,7 +482,7 @@
                 .item-box__content__num__price ¥ 4,500
                 - if true
                   .item-box__content__num__likes
-                    %i.far.fa-heart
+                    = fa_icon "heart-o"
                     %span 1
       .view-all
         %a{:href => "https://mercari.com/jp/category/2/"} すべての商品を見る


### PR DESCRIPTION
## Why
- CDNの記述を残したままデプロイしたため、gemでインストールしたfont-awesomeのアイコンが表示されなくなるエラーが発生。余計な記述を削除しました。

## What
- CDNの削除
- _main.html.hamlでfont-awesomeのCDN版で記述していた箇所をgem版に編集