### PR TITLE
delete user_sample.jpeg

### DIFF
--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -49,6 +49,6 @@
           
           %li.header__menu-box--right__list
             = link_to root_path do
-              = image_tag "user_sample.jpeg",width: "32", height: "32", class: 'header__menu-box--right__list__photo'
+              = image_tag "",width: "32", height: "32", class: 'header__menu-box--right__list__photo'
               %span<>
               マイページ


### PR DESCRIPTION
# WHY
画像の取り込みでサーバーエラーとなるため
# WHAT
_header.html.hamlに記述されているuser_sample.jpegを削除