### PR TITLE
Fix product detail page

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -2,4 +2,5 @@ class Delivery < ApplicationRecord
   belongs_to :product, optional: true
   belongs_to :deliver_method
   belongs_to :estimated_date
+  belongs_to :deliver_region
 end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -63,12 +63,12 @@
     .product__price
       %span.product__price__bold
         ¥
-        = @product.price
+        = number_with_delimiter @product.price
       %span.product__price__tax (税込)
       %span.product__price__shipping-fee 送料込み
     .product__user-sales
       .product__user-sales__balloon
-        売上金¥#{@product.price}をお持ちです
+        売上金¥#{number_with_delimiter @product.price}をお持ちです
     .product__buy-btn
       %a.buy-btn 購入画面に進む
       -# = link_to 'hogehoge_path', class: 'buy-btn'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -56,7 +56,8 @@
               %th 配送元地域
               %td 
                 = link_to '', class: 'text-link' do
-                  hugahuga県
+                  = @product.delivery.deliver_region.region
+
             %tr
               %th 発送日の目安
               %td hugaそのうち

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -8,8 +8,7 @@
       .product__main-contents
         .product__main-contents__photo
           .product__main-contents__photo-main
-            = image_tag 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ_-t6zzgr_FN4aAytpoYRUHe4pYoHIZ9ke_ZglKwCbJuKZCiyekg'
-            -# = @product.product_images.image イメージカラムがないのでエラー
+            = image_tag "#{@product.product_images[0].image}"
           .product__main-contents__photo-others 
         %table.product__main-contents__details
           %tbody
@@ -48,10 +47,12 @@
                 = @product.condition.condition
             %tr
               %th 配送料の負担
-              %td hogehoge負担
+              %td 
+                = @product.delivery.shipping_fee
             %tr
               %th 配送の方法
-              %td hogehoge便
+              %td 
+                = @product.delivery.deliver_method.method
             %tr
               %th 配送元地域
               %td 
@@ -60,7 +61,8 @@
 
             %tr
               %th 発送日の目安
-              %td hugaそのうち
+              %td 
+                = @product.delivery.estimated_date.date
     .product__price
       %span.product__price__bold
         ¥


### PR DESCRIPTION
# WHY
未実装な部分のため。
商品詳細ページとして必須情報を表示する必要があるため

# WHAT
商品詳細ページにおける配送料負担、配送地域、発送日目安、商品画像の表示をDBから表示できるように修正
