### PR TITLE
Fix product#index

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,14 +1,14 @@
 class ProductsController < ApplicationController
   def index
-    # 下記、カテゴリとブランドの実装が終わり次第修正
-    @products_ladies = Product.where(id: 1..4)
-    @products_mens = Product.where(id: 5..8)
-    @products_kids = Product.where(id: 9..12)
-    @products_cosme = Product.where(id: 13..16)
-    @products_chanel = Product.where(id: 17..20)
-    @products_vuitton = Product.where(id: 21..24)
-    @products_supreme = Product.where(id: 25..28)
-    @products_nike = Product.where(id: 29..32)
+    products = Product.order("id DESC").limit(32)
+    @products_ladies = products[0..3]
+    @products_mens = products[4..7]
+    @products_kids = products[8..11]
+    @products_cosme = products[12..15]
+    @products_chanel = products[16..19]
+    @products_vuitton = products[20..23]
+    @products_supreme = products[24..27]
+    @products_nike = products[28..31]
   end
 
   def show

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -1,6 +1,6 @@
 %li.item-box
   -# 商品詳細ページのリンクは未記入
-  = link_to "#" do
+  = link_to product_path(product) do
     %figure.item-box__photo
       =image_tag "#{product.product_images[0].image}"
     .item-box__content

--- a/app/views/products/_product.html.haml
+++ b/app/views/products/_product.html.haml
@@ -1,5 +1,4 @@
 %li.item-box
-  -# 商品詳細ページのリンクは未記入
   = link_to product_path(product) do
     %figure.item-box__photo
       =image_tag "#{product.product_images[0].image}"


### PR DESCRIPTION
## What
- 出品した商品を、降順に表示(新着順に上から表示)
- (商品のカテゴリ機能は未実装の為、現時点ではidの降順)
- トップページ(products#index)から、商品詳細(products#show)へのリンクを作成

## Why
- 出品中の商品をトップページに表示し、その商品の詳細を見れるようにするため