### PR TITLE
Fix p detail parentcategory and product size

### DIFF
--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -81,11 +81,11 @@ a {
           width: 100%;
           tbody {
             tr {
+              font-size: 14px;
               th {
                 width: 39%;
                 height: 30px;
                 text-align: left;
-                font-weight: 400;
                 background: #fafafa;
                 padding: 8px;
                 border: 1px solid #f5f5f5;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -30,17 +30,26 @@
             %tr
               %th カテゴリー
               %td
+                - if @product.category.parent.parent.present?
+                  = link_to '', class: 'text-link' do
+                    = @product.category.parent.parent.category
+                - if @product.category.parent.present?
+                  = link_to '', class: 'text-link' do
+                    = @product.category.parent.category
                 = link_to '', class: 'text-link' do
-                  = @product.category.parent.parent.category
-                = link_to '', class: 'text-link' do 
-                  = @product.category.parent.category
-                = link_to '', class: 'text-link' do 
                   = @product.category.category
+          
             %tr
               %th ブランド
               %td
-                =link_to '', class: 'text-link' do 
-                  = @product.brand.brand
+                - if @product.brand.present?
+                  =link_to '', class: 'text-link' do 
+                    = @product.brand.brand
+            - if @product.size.present?
+              %tr
+                %th 商品のサイズ
+                %td 
+                  = @product.size.size
             %tr
               %th 商品の状態
               %td 


### PR DESCRIPTION
# why
孫カテゴリーまで持たない商品がエラーとなっていたため

# what
・孫カテゴリーまで持たない商品詳細ページがエラーとなっていたため修正
・商品サイズの有無で表示の分岐をしていなかったため追加