### PR TITLE
fix user_controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,10 +43,13 @@ class UsersController < ApplicationController
       first_name: session[:first_name],
       family_name_pseudonym: session[:family_name_pseudonym],
       first_name_pseudonym: session[:first_name_pseudonym],
-      provider: session["devise.omniauth_data"]['provider'],
-      uid: session["devise.omniauth_data"]['uid']
-
     )
+
+    if session["devise.omniauth_data"].present?
+      @user[:provider] = session["devise.omniauth_data"]['provider']
+      @user[:uid] = session["devise.omniauth_data"]['uid']
+    end
+
     @user.build_address(user_params[:address_attributes])
     if @user.save
       session[:id] = @user.id


### PR DESCRIPTION
# why
SNSログインの実装後、メールアドレスでの新規登録でエラーとなっていたため

# what
SNS経由の場合で分岐するように修正