### PR TITLE
Create product controller destroy test

### DIFF
--- a/app/controllers/deliveraddresses_controller.rb
+++ b/app/controllers/deliveraddresses_controller.rb
@@ -17,7 +17,7 @@ class DeliveraddressesController < ApplicationController
     if @deliveraddress.save
       redirect_to root_path, notice: "新規作成完了"
     else
-      redirect_to new_user_deliveraddress_path, alert: "入力に誤りがあります。再度入力して下さい。"
+      redirect_to new_user_deliveraddress_path, alert: "入力に誤りがあります。"
     end
   end
 
@@ -26,7 +26,7 @@ class DeliveraddressesController < ApplicationController
     if @deliveraddress.update(deliveraddress_params)
       redirect_to root_path, notice: "編集が完了しました"
     else
-      redirect_to new_user_deliveraddress_path, alert: "未入力の項目がございました、もう一度入力して下さい。"
+      redirect_to new_user_deliveraddress_path, alert: "未入力の項目があります。"
     end
   end
 

--- a/app/controllers/deliveraddresses_controller.rb
+++ b/app/controllers/deliveraddresses_controller.rb
@@ -15,18 +15,18 @@ class DeliveraddressesController < ApplicationController
   def create
     @deliveraddress = Deliveraddress.new(deliveraddress_params)
     if @deliveraddress.save
-      redirect_to root_path
+      redirect_to root_path, notice: "新規作成完了"
     else
-      redirect_to new_user_deliveraddress_path
+      redirect_to new_user_deliveraddress_path, alert: "入力に誤りがあります。再度入力して下さい。"
     end
   end
 
   def update
     @deliveraddress = Deliveraddress.find(params[:id])
     if @deliveraddress.update(deliveraddress_params)
-      redirect_to root_path
+      redirect_to root_path, notice: "編集が完了しました"
     else
-      redirect_to new_user_deliveraddress_path
+      redirect_to new_user_deliveraddress_path, alert: "未入力の項目がございました、もう一度入力して下さい。"
     end
   end
 

--- a/app/views/deliveraddresses/_form.html.haml
+++ b/app/views/deliveraddresses/_form.html.haml
@@ -1,4 +1,5 @@
 .default-containers
+  = render 'layouts/notifications'
   = render './products/header'
   .usersMypage__contents
     .usersMypage__contents__wrapper.clearfix

--- a/spec/controllers/deliveraddresses_controller_spec.rb
+++ b/spec/controllers/deliveraddresses_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe DeliveraddressesController, type: :controller do
-  let(:user) {create(:user)}
 
   describe 'GET #new' do
+    let(:user){create(:user)}
     context 'log in' do
       before do
         login user
@@ -21,19 +21,108 @@ describe DeliveraddressesController, type: :controller do
   end
 
   describe 'GET #edit' do
+    let(:user){create(:user)}
+    context 'log in' do
+      before do
+        login user
+        @deliveraddress = build(:deliveraddress)
+        get :edit, params: { id: @deliveraddress, user_id: user.id}
+      end
+
+      it "has a 200 status code" do
+        expect(response.status).to eq 200
+      end
+
+      it "renders the :edit template" do
+        deliveraddress = @deliveraddress
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:user){create(:user)}
+    let(:params) do {
+      params: {
+        deliveraddress: {
+          family_name: "太郎",
+          first_name: "山田",
+          family_name_pseudonym: "ヤマダ",
+          first_name_pseudonym: "タロウ",
+          post_number: "123-4559",
+          prefecture: "北海道",
+          city: "横浜市",
+          street: "青梅",
+          building: "",
+          phone_number: "",
+          created_at: "2019-09-09 00-00-00",
+          updated_at: "2019-09-09, 00-00-00",
+          id: "1"
+        },
+        user_id: "1",
+      }
+    }
+    end
+
     before do
       login user
-      @deliveraddress = build(:deliveraddress)
-      get :edit, params: { id: @deliveraddress, user_id: user.id}
     end
 
-    it "has a 200 status code" do
-      expect(response.status).to eq 200
+    it "saves the new product in the database" do
+      expect do
+        post :create, params
+      end.to change(Deliveraddress, :count).by(1)
     end
 
-    it "renders the :edit template" do
-      deliveraddress = @deliveraddress
-      expect(response).to render_template :edit
+    it "redirects to products#index" do
+      post :create, params
+      expect(response).to redirect_to root_path
+    end
+  end
+
+
+  describe 'PATCH #update' do
+    let(:user){create(:user)}
+    let(:params) do
+      { params: {
+        deliveraddress: {
+          family_name: "山田",
+          first_name: "太郎",
+          family_name_pseudonym: "ヤマダ",
+          first_name_pseudonym: "タロウ",
+          post_number: "123-4559",
+          prefecture: "北海道",
+          city: "横浜市",
+          street: "青山1-1-1",
+          building: "",
+          phone_number: "",
+          created_at: "2019-09-09 00-00-00",
+          updated_at: "2019-09-09, 00-00-00",
+          },
+        id: "1",
+        user_id: "1"
+        }
+      }
+    end
+    before do
+      @deliveraddress = create(:deliveraddress,id: "1", user_id: user.id)
+      login user
+    end
+
+    it "リクエストは302 OKとなること" do
+      patch :update, params
+      expect(response.status).to eq 302
+    end
+
+    it "データベースのdeliveraddressが更新されること" do
+      expect do
+        patch :update, params
+      end.to change(Deliveraddress, :count).by(0)
+    end
+
+    it "root_pathへリダイレクトされる" do
+      patch :update, params
+      expect(response).to redirect_to root_path
     end
   end
 end


### PR DESCRIPTION
# What
・deliveraddressのcreateアクションとupdateアクションのテスト
・発送元・お届け先住所変更入力時のエラーハンドリング

# Why
・createアクションとupdateアクションのテストが無かった為
・エラーハンドリングが作成されていなかった為。
・入力ミスや完了した時に、完了した場合と失敗した場合にflash・alertを用いて分かり易くさせる