### PR TITLE
Change migrationfile address and deliveraddress

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,7 +1,9 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :post_number, presence: true
+  VALID_POST_NUMBER = /\A\d{3}[-]\d{4}\z|\A\d{3}[-]\d{2}\Z|\A\d{3}\z|\A\d{5}\z|\A\d{7}\z/
+
+  validates :post_number, presence: true, format: {with: VALID_POST_NUMBER}
   validates :prefecture, presence: true
   validates :city, presence: true
   validates :street, presence: true

--- a/db/migrate/20190829065555_add_column.rb
+++ b/db/migrate/20190829065555_add_column.rb
@@ -1,7 +1,7 @@
 class AddColumn < ActiveRecord::Migration[5.2]
   def up
     # add_reference :products, :seller, foreign_key: {to_table: :users}
-    change_column :addresses, :post_number, :integer, null: false
+    change_column :addresses, :post_number, :string, null: false
     change_column :addresses, :prefecture, :string, null: false
     change_column :addresses, :city, :string, null: false
     change_column :addresses, :street, :string, null: false

--- a/db/migrate/20190903053819_create_deliveraddresses.rb
+++ b/db/migrate/20190903053819_create_deliveraddresses.rb
@@ -5,7 +5,7 @@ class CreateDeliveraddresses < ActiveRecord::Migration[5.2]
       t.string        :first_name, null: false
       t.string        :family_name_pseudonym, null: false
       t.string        :first_name_pseudonym, null: false
-      t.integer       :post_number
+      t.string        :post_number
       t.string        :prefecture
       t.string        :city
       t.string        :street


### PR DESCRIPTION
# What
addressとdeliveraddressのpost_numberをinteger型からstring型へ変更
addressモデルにバリデーションを追加

# Why
integerでは「 - 」(ハイフン)を正常に保存できないので、string型に変更する必要があった為
addressモデルのpost_numberに　「-」(ハイフン)あり／なし　でも保存される様にする為に、バリデーションを加える必要があった