### PR TITLE
Update credit_card_controller

### DIFF
--- a/app/controllers/credit_card_controller.rb
+++ b/app/controllers/credit_card_controller.rb
@@ -3,8 +3,9 @@ class CreditCardController < ApplicationController
   require "payjp"
 
   def new
+    @path = Rails.application.routes.recognize_path(request.referer)
     card = CreditCard.where(user_id: current_user.id)
-    redirect_to user_credit_card_path(current_user, card) if card.exists?
+    redirect_to user_credit_card_path(current_user, card.id) if card.exists?
   end
 
   def pay #payjpとCardのデータベース作成を実施します。
@@ -20,7 +21,13 @@ class CreditCardController < ApplicationController
       ) #念の為metadataにuser_idを入れましたがなくてもOK
       @card = CreditCard.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to user_credit_card_path(current_user, @card), notice: 'クレジットカードを登録しました。'
+        if params[:before_controller] == "purchases"
+          product = params[:before_product]
+          redirect_to new_product_purchase_path(product), notice: 'クレジットカードを登録しました。'
+        else
+          redirect_to user_credit_card_path(current_user, @card), notice: 'クレジットカードを登録しました。'
+        end
+
       else
         redirect_to pay_user_credit_card_index_path(current_user), danger: 'クレジットカードの登録に失敗しました。'
       end

--- a/app/views/credit_card/new.html.haml
+++ b/app/views/credit_card/new.html.haml
@@ -21,5 +21,7 @@
         = f.label :セキュリティコード, class: 'label'
         %span 必須
         = f.text_field :cvc, type: 'text', class: 'input-number', placeholder: 'カード背面4桁もしくは3桁の番号', maxlength: "4"
+        = f.hidden_field  :before_controller, value: "#{@path[:controller]}", type: "hidden"
+        = f.hidden_field  :before_product, value: "#{@path[:product_id]}", type: "hidden"
       .content-bottom#card_token
         = f.submit '追加する', class: 'content-bottom--add-btn', id: 'token_submit'

--- a/app/views/purchases/new.html.haml
+++ b/app/views/purchases/new.html.haml
@@ -81,7 +81,7 @@
             = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?944967624", width: "49", height: "15"
           = link_to user_credit_card_path(current_user, current_user.credit_card), class: "purchase-container__payment__inner__change-button" do
             %span
-              登録する
+              変更する
             /iconは仮置き
             %i.icon >
         - else


### PR DESCRIPTION
## Why
- クレジットカード登録後のredirect先を、分岐させるように改良

## What
- クレジットカード未登録時、商品購入画面からクレジットカード登録画面 -> カードcreate -> 商品購入画面にredirectするようにした
- マイページからカード登録した場合は、カードcreate後、マイページにredirect