### PR TITLE
Fix userphoto icon

### DIFF
--- a/app/views/users/_evaluations.html.haml
+++ b/app/views/users/_evaluations.html.haml
@@ -2,10 +2,11 @@
   = link_to introduction_user_path(evaluation.buyer.id) do
     %ul
       %li.usersEvaluations--image
-        - if evaluation.buyer.photo == "0"
-          = image_tag "https://static.mercdn.net/images/member_photo_noimage_thumb.png"
+        - if evaluation.seller.photo?
+          = image_tag evaluation.seller.photo.url, class: 'introduction-container__top__user-photo__adjuster'
         - else
-          = evaluation.buyer.photo
+          = image_tag "//static.mercdn.net/images/member_photo_noimage.png", class: 'introduction-container__top__user-photo__adjuster'
+        
       %li.usersEvaluations--text
         - if evaluation.rating == 1
           = fa_icon "smile-o", id: "userEvaluations--text__good"
@@ -24,4 +25,3 @@
         = evaluation.created_at.strftime("%Y年%-m月%-d日 %-H時%-M分")
       %li.usersEvaluations--awesome
         = fa_icon "chevron-right"
-

--- a/app/views/users/all_evaluations.html.haml
+++ b/app/views/users/all_evaluations.html.haml
@@ -34,8 +34,7 @@
                   = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?66407541"
                   %p 投稿された評価がありません
             - else
-              - @all_evaluations.each do |evaluation|
-                = render partial: "evaluations", collection: @all_evaluations, as: "evaluation"
+              = render partial: "evaluations", collection: @all_evaluations, as: "evaluation"
   
   = render './products/button'
   = render './products/aside'

--- a/app/views/users/bad_evaluations.html.haml
+++ b/app/views/users/bad_evaluations.html.haml
@@ -34,8 +34,7 @@
                   = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?66407541"
                   %p 投稿された評価がありません
             - else
-              - @bad_evaluations.each do |evaluation|
-                = render partial: "evaluations", collection: @bad_evaluations, as: "evaluation"
+              = render partial: "evaluations", collection: @bad_evaluations, as: "evaluation"
 
   = render './products/button'
   = render './products/aside'

--- a/app/views/users/good_evaluations.html.haml
+++ b/app/views/users/good_evaluations.html.haml
@@ -34,8 +34,7 @@
                   = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?66407541"
                   %p 投稿された評価がありません
             - else
-              - @good_evaluations.each do |evaluation|
-                = render partial: "evaluations", collection: @good_evaluations, as: "evaluation"
+              = render partial: "evaluations", collection: @good_evaluations, as: "evaluation"
 
   = render './products/button'
   = render './products/aside'

--- a/app/views/users/introduction.html.haml
+++ b/app/views/users/introduction.html.haml
@@ -6,7 +6,11 @@
     .introduction-container
       .introduction-container__top
         .introduction-container__top__user-photo
-          = image_tag "https://cdn.pixabay.com/photo/2016/05/17/22/16/baby-1399332_1280.jpg", class:'introduction-container__top__user-photo__adjuster'
+          - if @user.photo?
+            = image_tag @user.photo.url, class: 'introduction-container__top__user-photo__adjuster'
+          - else
+            = image_tag "//static.mercdn.net/images/member_photo_noimage.png", class: 'introduction-container__top__user-photo__adjuster'
+        
         .introduction-container__top__user-nickname
           = @user.nickname
         .introduction-container__top__user-score

--- a/app/views/users/mypage.html.haml
+++ b/app/views/users/mypage.html.haml
@@ -19,10 +19,10 @@
         %ul
           %li
             %span 評価
-            3
+            #{Evaluation.group(:seller_id).size[current_user.id].to_i}
           %li
             %span 出品数
-            0
+            #{Product.group(:seller_id).size[current_user.id].to_i}
 
 
       .usersMypage__contents__wrapper__right__tabs

--- a/app/views/users/normal_evaluations.html.haml
+++ b/app/views/users/normal_evaluations.html.haml
@@ -34,8 +34,7 @@
                   = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?66407541"
                   %p 投稿された評価がありません
             - else
-              - @normal_evaluations.each do |evaluation|
-                = render partial: "evaluations", collection: @normal_evaluations, as: "evaluation"
+              = render partial: "evaluations", collection: @normal_evaluations, as: "evaluation"
 
   = render './products/button'
   = render './products/aside'


### PR DESCRIPTION
# why
ユーザー登録の写真が表示されない仕様となっていたため

# what
マイページ上部の評価数出品数を反映

以下のページへ、ユーザーの写真が反映されるように修正
・ユーザー紹介ページ
https://i.gyazo.com/85570665f0c4f51105bc7a37854ae234.png
・評価一覧
https://i.gyazo.com/ae8bedfec4b6babc536511654b63e0f8.png