### PR TITLE
Update _header.html.haml

### DIFF
--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -154,7 +154,8 @@
           
             %li.header__menu-box--right__list
               = link_to mypage_user_path(current_user.id) do
-                - if current_user.photo.to_s == "/uploads/user/photo/#{current_user.id}/0"
+
+                - if current_user.attributes["photo"].to_i == 0
                   = image_tag "/images/mercari_user.png", class: 'header__menu-box--right__list__photo'
                 - else
                   = image_tag current_user.photo.url, class: 'header__menu-box--right__list__photo'


### PR DESCRIPTION
## Why
- 本番環境で、ユーザーのプロフィール画像未登録の場合、デフォルト画像が表示されたいため改修

## What
- 現状、current_user.photoを取り出し、保存先のURLを判定して画像登録の有無を確認していたが、本番環境では画像データがS3に保存されるため、そのURLが無効なことが判明
- URLの判定ではなく、Usersテーブルに保存されたphotoカラムの値(画像未登録の場合"0")を判定するようにした