### PR TITLE
Update ransack.rb

### DIFF
--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -2,5 +2,5 @@ Ransack.configure do |config|
 
   config.add_predicate 'has_every_term',
                         arel_predicate: 'matches_all',
-                        formatter: proc { |v| v.split.map { |t| "%#{t}%" } }
+                        formatter: proc { |v| v.split(/[ |　]/).map { |t| "%#{t}%" } }
 end


### PR DESCRIPTION
## Why
- 商品検索で複数ワード検索の時に、全角スペースだと検索されないため、改修を行った

## What
- 複数の検索ワードを半角スペース、全角スペースともに区切り文字として認識されるように改修した